### PR TITLE
v1.2.3 : reduce log messages and fix comms issues that kill framework

### DIFF
--- a/runset.py
+++ b/runset.py
@@ -10,9 +10,10 @@ if __name__ == '__main__':
     #cmd.add_argument('--run', action='store_true')
     #cmd.add_argument('--tests', action='store_true')
     #cmd.add_argument('--configs', action='store_true')
-    p.add_argument('--iceboot_host', '--host', '-H', type=str, default=None)
-    p.add_argument('--iceboot_port', '--port', '-p', type=str, default=None)
-    p.add_argument('--iceboot_debug', '-D', action='store_true', default=False)
+    cfg_conn = stf.config.getIcebootOpts()
+    p.add_argument('--iceboot_host', '--host', '-H', type=str, default=cfg_conn.host)
+    p.add_argument('--iceboot_port', '--port', '-P', type=str, default=cfg_conn.port)
+    p.add_argument('--iceboot_debug', '-D', action='store_true', default=cfg_conn.debug)
 
     args = p.parse_args()
     setName = args.set_name

--- a/stf/__init__.py
+++ b/stf/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from collections import OrderedDict
 
-__version__ = '1.2.2'
+__version__ = '1.2.3'
 FRAMEWORK_VERSION = __version__
 FRAMEWORK_VERSIONNAME = 'Chernobyl'
 

--- a/stf/core.py
+++ b/stf/core.py
@@ -23,7 +23,7 @@ from . import db
 from stf.debug import dbg, DEBUG
 from stf import getRegisteredClasses, getRegisteredClassesByName, getClassContext, getRegisteredClass, _PRINT, delClassContext, INFO, ginfo 
 from .parse import SetConfig
-from .util import files 
+from .util import files, misc
 from .util.colors import termcolor as tc
 from .util.config import get_config
 
@@ -56,6 +56,7 @@ class FakeIceboot(object):
             return lambda: int(CONFIG.settings.iceboot.fw_version, 16)
         return fake
 
+@misc.try_repeat(repeat_limit=3, sleep=3, msg='unable to create connection... trying again', exc_cls=(OSError, IOError, UnicodeDecodeError))
 def getIcebootSession(**kw):
     if DEBUG.FAKE_ICEBOOT:
         return FakeIceboot(**kw)
@@ -68,10 +69,13 @@ def getIcebootSession(**kw):
 
     dbg('Starting iceboot session ...')
     dbg(f'  {CONFIG.settings.iceboot}')
+
+    session = iceboot_session_cmd.init(IcebootOpts, **kw)
+    return session
+    '''
     session = None
     fail_count = 0
-    # XXX:
-    #kw = CONFIG.getIcebootOpts()
+
     while session is None and fail_count < 5:
         try:
             # this sleep prevents OSError from being thrown in some
@@ -89,6 +93,7 @@ def getIcebootSession(**kw):
                 raise
 
     return session
+    '''
 
 
 def getDevices(device_type=None):
@@ -181,7 +186,7 @@ def run_set(set_name=None, config_file=None, list_tests=False, list_overrides=Fa
         for test in setConfig.tests:
             d = CONFIG.get_path('tests')
             testFile = f'{d}/{test}.py'
-            dbg('verifying testfile {} ...'.format(testFile))
+            #dbg('verifying testfile {} ...'.format(testFile))
             try:
                 with open(testFile) as f:
                     testCode = f.read()
@@ -195,11 +200,13 @@ def run_set(set_name=None, config_file=None, list_tests=False, list_overrides=Fa
         setConfig.configure()
         
         #dbg('registered_tests: {}'.format(getRegisteredClassesByName().keys())) 
-        dbg(setConfig.instances)
+        #dbg(setConfig.instances)
 
         # maybe the results path should include results/setname/{dut_id}-{timeSlug} wehre timeSlug has minutes precision (or we just add sequence numbers...
         # maybe dut_id-suquence-timeslug? since the 
-        # XXX: just thought of this; should timeSlug be property of class at time of instantion? or passed from runset code? because it should be the same for all test outputs...
+        # XXX: just thought of this; should timeSlug be property of class at
+        # time of instantion? or passed from runset code? because it should be
+        # the same for all test outputs...
         '''
         files.ensureEmptyDir(
             root=CONFIG.get_path('results'),
@@ -225,9 +232,8 @@ def run_set(set_name=None, config_file=None, list_tests=False, list_overrides=Fa
 
 
 def runset_thread(setConfig, device_host, device_port, device_type, list_tests=False, list_overrides=False):
-    def debug(s):
-        dbg('XXX: {}:{}:{} {}'.format(setConfig.set_name, device_host, device_port, s))
-    debug('Creating results dir for {setConfig.set_name}/{setConfig.time_slug}')
+    dbg('set:host:port => {}:{}:{}'.format(setConfig.set_name, device_host, device_port))
+    #debug('Creating results dir for {setConfig.set_name}/{setConfig.time_slug}')
 
     # check for board ID
     dut_id = getBoardID(host=device_host, port=device_port)
@@ -243,8 +249,8 @@ def runset_thread(setConfig, device_host, device_port, device_type, list_tests=F
 
     for test in setConfig.instances:
         testName = test['test_name']
-        debug('running: {}'.format(test['testinstance_name']))
-        debug('   with: {}'.format(test))
+        #debug('running: {}'.format(test['testinstance_name']))
+        #debug('   with: {}'.format(test))
 
         # XXX: refactor test/config listing to be insdie of setConfig
         # then modify runset script to just ask setConfig for this stuff
@@ -263,7 +269,7 @@ def runset_thread(setConfig, device_host, device_port, device_type, list_tests=F
         with open(testFile) as f:
             testCode = f.read()
             code = f"""\nstf.core.run_single_test("{testName}", "{test['instance_name']}", "{setConfig.set_name}", {test['args']}, {test['expectedValues']}, "{setConfig.time_slug}", "{dut_id}", "{device_type}", "{device_host}", "{device_port}")"""
-            debug(f'code: {code}')
+            #debug(f'code: {code}')
             cc = getClassContext(testName)
             exec(compile(testCode + code, testFile, 'exec'), cc[2])
 
@@ -274,7 +280,7 @@ def run_single_test(name, instance, group, args, evs, timeslug,
     cName = tc(name, 'aqua')
     cInst = tc(instance, 'aqua')
 
-    INFO(f'Running {cName}:{cInst}', groups=['runset', 'framework'])
+    #INFO(f'Running {cName}:{cInst}', groups=['runset', 'framework'])
 
     # XXX: copy class info? clone method? maybe just 
     # return new Test object with test.reconfigure()?
@@ -306,6 +312,11 @@ def run_single_test(name, instance, group, args, evs, timeslug,
         INFO(f'Exception raised during test {name}:{instance}')
 
 
+# issue#51: unicode decode error kills framework
+# (not sure if this happens here, but now it shouldn't
+@misc.try_repeat(repeat_limit=3, sleep=1, exc_cls=(UnicodeDecodeError),
+    msg=('Got UnicodeDecodeError when attempting to call "flashID"... '
+         'trying again'))
 def getBoardID(host=None, port=None):
     session = getIcebootSession(host=host, port=port)
     x = session.flashID()

--- a/stf/decorators.py
+++ b/stf/decorators.py
@@ -65,7 +65,7 @@ def register(**kw):
     conf_file = kw.get('config_file')
     if not conf_file:
         conf_file = '{}/{}.json'.format(stf.config.get_path('testconfig'), name)
-        stf.dbg(f'config_file not provided test "{name}"; trying {conf_file}')
+        #stf.dbg(f'config_file not provided test "{name}"; trying {conf_file}')
         # XXX: validate config here?, raise Exception
 
     version = kw.get('version')

--- a/stf/testclasses.py
+++ b/stf/testclasses.py
@@ -8,7 +8,6 @@ from .core import getIcebootSession
 from .validators import *
 import stf
 from .util.colors import termcolor as clr
-#from .util.misc import INFO, check_mainboard_fwfile, getTimeSlug
 from .util import files, misc
 FAKE_ICEBOOT = False
 

--- a/stf/testclasses.py
+++ b/stf/testclasses.py
@@ -220,7 +220,8 @@ class MainboardTest(object):
             del self.session
             stf.debug('teardown complete')
         
-    # XXX: should wrap this with try_repeat?
+    '''
+    # OLD teardown fn (pre try_repeat... probably won't need this)
     def XXX_tearDown(self, test):
         if self.session:
             if hasattr(self.session, 'FAKE'):
@@ -242,6 +243,7 @@ class MainboardTest(object):
                     stf.debug('got UnicodeDecodeError when closing iceboot session... continuing if possible')
                     
             stf.debug('teardown complete')
+    '''
 
 
     # used for test sets

--- a/stf/testclasses.py
+++ b/stf/testclasses.py
@@ -8,8 +8,8 @@ from .core import getIcebootSession
 from .validators import *
 import stf
 from .util.colors import termcolor as clr
-from .util.misc import INFO, check_mainboard_fwfile, getTimeSlug
-from .util import files
+#from .util.misc import INFO, check_mainboard_fwfile, getTimeSlug
+from .util import files, misc
 FAKE_ICEBOOT = False
 
 # class TestSet(object):
@@ -33,33 +33,37 @@ class Common(object):
     def checkCommsAndFirmware(test, session, **kw):
         gINFO = stf.ginfo(['framework', 'iceboot'])
         vn = session.fpgaVersion()
-        stf.dbg('running framework FW test, got vn: {} (expecting {})'.format(hex(vn), kw['expectedValues']['expected_fw_vnum']))
 
         paths = stf.config.settings.paths
 
         flash = session.flashLS()
 
         try:
-            fwfile_status = check_mainboard_fwfile(flash)
+            fwfile_status = misc.check_mainboard_fwfile(flash)
         except FileNotFoundError as e:
-            gINFO(f'FW File does not exist: {e}')
+            gINFO(f'FW File does not exist: {e}. Cannot proceed.')
             return stf.STOP
 
-        gINFO(f'checking flash for {paths.fwfile} ... status={fwfile_status})')
+        #gINFO(f'checking flash for {paths.fwfile} ... status={fwfile_status})')
 
         if fwfile_status == 'ok':
-            gINFO(f'checkCommsAndFirmware -> configuring fw file from flash: {paths.fwfile_name})')
+            stf.dbg(f'checkCommsAndFirmware -> configuring fw file from flash: {paths.fwfile_name})')
         elif fwfile_status == 'skip':
-            gINFO(f'checkCommsAndFirmware -> SKIPPING fw file upload, configuring: {paths.fwfile_name}')
+            stf.dbg(f'checkCommsAndFirmware -> SKIPPING fw file upload, configuring: {paths.fwfile_name}')
         else:
-            gINFO(f'checkCommsAndFirmware -> uploading fw file to flash: {paths.fwfile}... \n\t(this could take a while)')
+            stf.dbg(f'checkCommsAndFirmware -> uploading fw file to flash: {paths.fwfile}... \n\t(this could take a while)')
             session.ymodemFlashUpload(paths.fwfile_name, paths.fwfile)
 
         resp = session.flashConfigureCycloneFPGA(paths.fwfile_name)
         vn = session.fpgaVersion()
-        stf.dbg(f'checkComms: vn={vn}; flashConfigure says "{resp}"')
+        stf.dbg(f'checkComms: vn={hex(vn)}; flashConfigure says "{resp}"')
+        # XXX: check with jim; fpgaVersion should now wait for flashConfigure
+        # to complete (or flashConfigure blocks until configured and
+        # fpgaVersion will return proper val? so we don't need a sleep?
         time.sleep(1)
 
+        # XXX: might not need to check comms repeatedly anymore, and 
+        # if we do need to should refactor with try_repeat
         commsOk = False
         commsChecks = 5
         while commsChecks > 0:
@@ -88,7 +92,8 @@ class Common(object):
             test.measurements.fpgaChipID = 'unset'
 
         x = test.measurements
-        stf.debug(f'FPGA v{vn} Configured. IceBoot v{x.softwareVersion} git: {x.softwareId} FPGA ID: {x.fpgaChipID}')
+        evn = kw['expectedValues']['expected_fw_vnum']
+        stf.debug(f'FPGA v{hex(vn)} Configured (expecting={evn}). IceBoot v{x.softwareVersion} git: {x.softwareId} FPGA ID: {x.fpgaChipID}')
         stf.debug('Starting main test phase...')
 
 
@@ -111,7 +116,7 @@ class MainboardTest(object):
         # instance can be none
         self.instance = kw.get('instance', 'base')
 
-        stf.dbg('creating MainboardTest class for: {}:{}'.format(test_name, self.instance))
+        #stf.dbg('creating MainboardTest class for: {}:{}'.format(test_name, self.instance))
 
         #self.session = None
         # XXX: move to init or "configure" step or something
@@ -182,6 +187,7 @@ class MainboardTest(object):
 
     # Process any queued MCU internal logging records
     def logOutput(self, test):
+        '''may throw UnicodeDecodeError'''
         logOutputLines = self.session.printLogOutput()
         if len(logOutputLines) == 0:
             return
@@ -202,27 +208,42 @@ class MainboardTest(object):
             logFn('MCU log: ' + logLine)
 
 
+    @misc.try_repeat(exc_cls=(UnicodeDecodeError, OSError, IOError))
     def tearDown(self, test):
         if self.session:
             if hasattr(self.session, 'FAKE'):
                 return
+            stf.debug('tearing down test/iceboot ... initiating device reboot()')
             self.logOutput(test)
-            INFO('tearing down ... initiating reboot()')
-            # XXX:rebootafter
+            self.session.reboot()
+            stf.debug('attempting to shutdown and close socket comms...')
+            self.session.close()
+            del self.session
+            stf.debug('teardown complete')
+        
+    # XXX: should wrap this with try_repeat?
+    def XXX_tearDown(self, test):
+        if self.session:
+            if hasattr(self.session, 'FAKE'):
+                return
             try:
+                stf.debug('tearing down test/iceboot ... initiating device reboot()')
+                self.logOutput(test)
                 self.session.reboot()
             except (OSError, IOError):
                 stf.debug('oserror thrown by reboot (semi-expected)')
+            except UnicodeDecodeError:
+                stf.debug('got UnicodeDecodeError when tearing down... trying to close session')
             finally:
-                stf.debug('attempting to shutdown and close socket comms...')
-                self.session.close()
-                del self.session
+                try:
+                    stf.debug('attempting to shutdown and close socket comms...')
+                    self.session.close()
+                    del self.session
+                except UnicodeDecodeError:
+                    stf.debug('got UnicodeDecodeError when closing iceboot session... continuing if possible')
+                    
             stf.debug('teardown complete')
 
-
-    # DEPRECATED
-    def addTest(self, testCallable):
-        self.tests.append(testCallable)
 
     # used for test sets
     def reconfigure(self, name, group, args, evs, timeslug='', config={}):
@@ -249,11 +270,6 @@ class MainboardTest(object):
         )
 
     def getTestParams(self):
-        '''
-        self._PARAMS is dict of {
-        }
-        '''
-        # XXX: this requires @configure deco
         if hasattr(self, '_PARAMS'):
             return self._PARAMS
 
@@ -287,23 +303,13 @@ class MainboardTest(object):
         dut_host = x.get('host') or stf.config.settings.iceboot.host
         dut_port = x.get('port') or stf.config.settings.iceboot.port
 
-        # TODO: get test desc (or keep this in DB and link to test name)
-        desc = 'todo'
-
         stf.dbg('test args: {}'.format(test_args))
         stf.dbg('expected values: {}'.format(expected_values))
 
-        # XXX: move this to seutp function or re-implement this as a plug?
-        #try:
         self.session = getIcebootSession(host=dut_host, port=dut_port)
-        #except:
-        #    self.session = None
-        #    stf.dbg('Lots of OSErrors... sleeping for 10...')
-        #    time.sleep(10)
-        #    self.session = getIcebootSession(host=dut_host, port=dut_port)
 
-        # XXX:rebootfirst
         '''
+        # XXX:rebootfirst
         try:
             stf.debug('rebooting device...')
             self.session.reboot()
@@ -365,7 +371,6 @@ class MainboardTest(object):
                 group_timeslug,
                 output.json.filename
             )
-            stf.debug(f'jsonout path: {p}')
             T.add_output_callbacks(
                 JSON(p, indent=4, default=str)
             )
@@ -382,7 +387,5 @@ class MainboardTest(object):
         T.descriptor.metadata['board_softwareVersion'] = session.fpgaVersion
         T.descriptor.metadata['board_softwareId'] = session.fpgaVersion
         '''
-        #self.T = T
 
-        INFO(f'Finished {self.test_name}')
         stf.dbg("finished execute for test: {}".format(self.test_name))

--- a/stf/util/config.py
+++ b/stf/util/config.py
@@ -1,5 +1,5 @@
 import json
-from .misc import flatten, jsonify
+from .misc import flatten, jsonify, JsObject
 from .. import parse
 from ..debug import DEBUG
 import os
@@ -79,7 +79,7 @@ class JsonConfig(object):
 
         
     def getIcebootOpts(self):
-        return dict(
+        return JsObject(
             host=self.settings.iceboot.host,
             port=self.settings.iceboot.port,
             debug=self.settings.iceboot.debug,

--- a/stf/util/misc.py
+++ b/stf/util/misc.py
@@ -5,6 +5,7 @@ from stf.util.files import getFileSize
 import stf
 import uuid
 from datetime import datetime
+import time
 
 
 def flatten(d, separator='.'):
@@ -108,6 +109,35 @@ def INFO(s, **kw):
         if not (set(groups) & set(__SHOW_GROUPS)):
             return
     _PRINT(clr('INFO >>> ', 'gray') + clr(s, 'gold'))
+
+
+# decorator to try a fn a couple times and sleep between, accepts 
+def try_repeat(repeat_limit=3, sleep=1, msg=None, exc_cls=(UnicodeDecodeError)):
+    '''
+    decorator to try a fn up to `repeat_limit` times with a sleep=`sleep` wait
+    
+    accepts `exc_cls` which is a TUPLE (important! not a list) of 
+    classes to except on and go ahead with retry
+    
+    optional msg will be printed to stf.debug if provided
+    '''
+    def actual_decorator(try_fn):
+        def wrap(*args, **kw):
+            # nonlocal so wrap fn can crawl up scope-chain to modify 
+            # repeat_limit
+            nonlocal repeat_limit
+            while repeat_limit:
+                try:
+                    return try_fn(*args, **kw)
+                except exc_cls as e:
+                    repeat_limit -= 1
+                    stf.debug(f'Exception: {e}; trying again after {sleep}s')
+                    if msg:
+                        stf.debug(msg)
+                    if sleep:
+                        time.sleep(sleep)
+        return wrap
+    return actual_decorator
 
 
 def check_mainboard_fwfile(flash):


### PR DESCRIPTION
v1.2.3 : reduce log messages and fix comms issues that kill framework

- dramatically reduced number of debug statements
- removed almost all INFO statements
- added `try_repeat` wrapper to all iceboot session stuff to prevent exceptions from bringing down framework (UnicodeDecodeError, IOError, OSError)

fixes #51
fixes #40
