### PR TITLE
12 4 fail known exceptions

### DIFF
--- a/stf/__init__.py
+++ b/stf/__init__.py
@@ -1,9 +1,15 @@
 from __future__ import print_function
 from collections import OrderedDict
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 FRAMEWORK_VERSION = __version__
 FRAMEWORK_VERSIONNAME = 'Chernobyl'
+
+# exception class for folks to throw known exceptions
+# NOTE: move to util/exceptions.py and include other STF-based exceptions that
+# are common across tests (if there are any)
+class STFException(Exception):
+    pass
 
 
 global TESTABLE_CLASSES

--- a/stf/testclasses.py
+++ b/stf/testclasses.py
@@ -18,6 +18,7 @@ FAKE_ICEBOOT = False
 
 class Common(object):
     # default test config options
+
     TEST_CONFIG = {
         'timeout_s': 10
     }
@@ -360,7 +361,10 @@ class MainboardTest(object):
             device=device,
             conn=config.get('iceboot', {})
         )
-        #T.configure(teardown_function=self.tearDown)
+        T.configure(
+            #teardown_function=self.tearDown
+            failure_exceptions=[stf.STFException]
+        )
 
         output = stf.config.settings.output
         if output.json.enabled:

--- a/tests/CheckFirmware.py
+++ b/tests/CheckFirmware.py
@@ -6,6 +6,7 @@ def run_test(test, session):
     fw_version = hex(session.fpgaVersion())
     test.logger.info('Got fw version: {}'.format(fw_version))
     test.measurements.fw_vnum = fw_version
+    raise stf.STFException('foobar')
     
 
 stf.register(

--- a/tests/CheckFirmware.py
+++ b/tests/CheckFirmware.py
@@ -6,7 +6,6 @@ def run_test(test, session):
     fw_version = hex(session.fpgaVersion())
     test.logger.info('Got fw version: {}'.format(fw_version))
     test.measurements.fw_vnum = fw_version
-    raise stf.STFException('foobar')
     
 
 stf.register(


### PR DESCRIPTION
allows tests to FAIL with known exceptions (anything inherited from `stf.STFException` or that exception itself)

e.g.

CheckFirmware.py
```
def run_test(...):
   ... blah blah
   if somethingIsBad:
       raise STFException("foobar")
```

Produces this JSON output result:
```
    "dut_id": "3c1c6c9cb3e2",
    "start_time_millis": 1583275213400,
    "end_time_millis": 1583275221075,
    "outcome": "FAIL",
    "outcome_details": [
        {
            "code": "STFException",
            "description": "foobar"
        }
    ],
    "metadata": {
        "test_name": "CheckFirmware",
...snip...
```