### PR TITLE
Improve STF version identification records

### DIFF
--- a/stf/__init__.py
+++ b/stf/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import print_function
 from collections import OrderedDict
+import subprocess as sp
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 FRAMEWORK_VERSION = __version__
 FRAMEWORK_VERSIONNAME = 'Chernobyl'
+GIT = 'git'
 
 # exception class for folks to throw known exceptions
 # NOTE: move to util/exceptions.py and include other STF-based exceptions that
@@ -38,6 +40,42 @@ def getRegisteredClassesByName():
 
 def getRegisteredClass(name):
     return TESTABLE_CLASSES[name]
+
+def versionStatus():
+    """ Return git workspace status:
+    '?' : unknown or not a git workspace
+    '!' : valid git workspace is modified
+    ''  : valid git workspace is prisine
+    """
+
+    status = '?'
+    try:
+        git = [ GIT, 'diff-index', '--quiet', 'HEAD']
+        modified = sp.call(git, stderr=sp.DEVNULL)
+        if modified == 0:
+            status = ''
+        elif modified == 1:
+            status = '!'
+    except:
+        pass
+
+    return status
+
+def versionHash():
+    """ Return git commit hash associated with workspace:
+    'xxxxxx' 6-character hash string or
+    '?' unknown
+    """
+    hash = '?'
+    try:
+        git = [ GIT, 'log', '-1', '--pretty=format:%h']
+        hash = sp.check_output(git, stderr=sp.DEVNULL).decode("utf-8")
+    except:
+        pass
+
+    return hash
+
+
 
 import sys
 import os

--- a/stf/testclasses.py
+++ b/stf/testclasses.py
@@ -333,7 +333,8 @@ class MainboardTest(object):
             },
             user_metadata=self.meta,
             # custom metadata fields
-            stf_version=stf.FRAMEWORK_VERSION,
+            stf_version=stf.FRAMEWORK_VERSION + stf.versionStatus(),
+            stf_versionHash = stf.versionHash(),
             stf_config=stf.config.settings.dict(),
             device=device,
             conn=config.get('iceboot', {})


### PR DESCRIPTION
Implements Issue #91
Bumps STF version 1.3.1 -> 1.3.2
Adds STF version suffix indicating clean/dirty git workspace.
Adds STF git workpace hash.